### PR TITLE
Added a way to set computer_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "azurerm_linux_virtual_machine" "VM" {
   admin_username                  = var.admin_username
   admin_password                  = var.admin_password
   disable_password_authentication = var.disable_password_authentication
-  computer_name                   = local.vm-name
+  computer_name                   = var.computer_name
   custom_data                     = var.custom_data
   size                            = var.vm_size
   priority                        = var.priority
@@ -170,7 +170,7 @@ resource "azurerm_linux_virtual_machine" "VM" {
       storage_account_uri = azurerm_storage_account.boot_diagnostic[0].primary_blob_endpoint
     }
   }
-  tags = local.tags
+  tags = merge(local.tags,[var.computer_name != null ? {"OsHostname" = var.computer_name}: null]...)
   lifecycle {
     ignore_changes = [
       # Ignore changes to tags, e.g. because a management agent

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "postfix" {
   default     = ""
 }
 
+variable "computer_name"{
+  description = "(Optional) VM OS Hostname"
+  type = string
+  default = null
+}
+
 variable "data_disks" {
   description = "Map of object of disk sizes in gigabytes and lun number for each desired data disks. See variable.tf file for example"
   type        = any


### PR DESCRIPTION
Can now set variable computer_name for the OS Hostname to be different than the Azure Resource name. 
If computer_name is different than the Azure Resource name, a tag OsHostName will automatically be created